### PR TITLE
Update Greenshot Install Params (ALLUSERS) NeverRed.ps1

### DIFF
--- a/NeverRed.ps1
+++ b/NeverRed.ps1
@@ -26175,6 +26175,7 @@ If ($Install -eq "1") {
                 "/NORESTARTAPPLICATIONS"
                 "/SUPPRESSMSGBOXES"
                 "/CLOSEAPPLICATIONS"
+		"/ALLUSERS"
             )
             DS_WriteLog "I" "Install $Product" $LogFile
             Write-Host -ForegroundColor Green "Update available"


### PR DESCRIPTION
Added the ALLUSERS install parameter to fix the uninstall key location.  With ALLUSERS the uninstall key goes to HKLM.  Without ALLUSERS the uninstall key goes to HKCU.