### PR TITLE
Restore Teams Meeting Add-in Outlook registration block

### DIFF
--- a/NeverRed.ps1
+++ b/NeverRed.ps1
@@ -23127,8 +23127,20 @@ If ($Install -eq "1") {
                     msiexec.exe /i "$((Get-ChildItem -Path 'C:\Program Files\WindowsApps' -Filter 'MSTeams*' | sort-object LastWriteTime -Descending | Select-Object -First 1).FullName)\MicrosoftTeamsMeetingAddinInstaller.msi" Reboot=ReallySuppress ALLUSERS=1 TARGETDIR="C:\Windows\Microsoft\TeamsMeetingAddin" /qn
                 }
                 Write-Host -ForegroundColor Green "Install $Product Add-In for Outlook finished!"
-                Write-Host "Register $Product Add-In for Outlook"Mi 
-                ngen wie immer si
+                Write-Host "Register $Product Add-In for Outlook"
+                If ($WhatIf -eq '0') {
+                    $appX64DLL = (Get-ChildItem -Path "C:\Windows\Microsoft\TeamsMeetingAddin\x64" -Include "Microsoft.Teams.AddinLoader.dll" -Recurse).FullName
+                    $appX86DLL = (Get-ChildItem -Path "C:\Windows\Microsoft\TeamsMeetingAddin\x86" -Include "Microsoft.Teams.AddinLoader.dll" -Recurse).FullName
+                    Start-Process -FilePath "$env:WinDir\SysWOW64\regsvr32.exe" -ArgumentList "/s /n /i:user `"$appX64DLL`"" -ErrorAction SilentlyContinue
+                    Start-Process -FilePath "$env:WinDir\SysWOW64\regsvr32.exe" -ArgumentList "/s /n /i:user `"$appX86DLL`"" -ErrorAction SilentlyContinue
+                    # Add Registry Keys for loading the Add-in
+                    If (!(Test-Path 'HKLM:\Software\Microsoft\Office\Outlook\Addins\')) {New-Item -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins\" | Out-Null}
+                    New-Item -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins" -Name "TeamsAddin.FastConnect" -Force -ErrorAction Ignore | Out-Null
+                    New-ItemProperty -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins\TeamsAddin.FastConnect" -Type "DWord" -Name "LoadBehavior" -Value 3 -force | Out-Null
+                    New-ItemProperty -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins\TeamsAddin.FastConnect" -Type "String" -Name "Description" -Value "Microsoft Teams Meeting Add-in for Microsoft Office" -force | Out-Null
+                    New-ItemProperty -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins\TeamsAddin.FastConnect" -Type "String" -Name "FriendlyName" -Value "Microsoft Teams Meeting Add-in for Microsoft Office" -force | Out-Null
+                    If (!(Test-Path 'HKLM:\Software\Microsoft\Office\Outlook\Addins\')) {New-Item -Path "HKLM:\Software\Microsoft\Office\Outlook\Addins\" | Out-Null}
+                }
                 Write-Host -ForegroundColor Green "Register $Product Add-In for Outlook finished!"
                 <#If (!(Get-ScheduledTask -TaskName "Teams Meeting AddIn for Microsoft Outlook" -ErrorAction SilentlyContinue)) {
                     Write-Host "Implement scheduled task to create settings.json file in the User Profile"


### PR DESCRIPTION
## Summary

This pull request restores the Outlook Add-In registration process for the Microsoft Teams / Teams 2 Meeting Add-in.

## Background

The registration block appears to be missing since version `2.10.81`:

`Version 2.10.81 - Correction Foxit Reader download and install / Correction Firefox version for download and install`

## Impact

Without this registration logic, the Microsoft Teams Meeting Add-in for Outlook is not registered correctly.

## Changes

- Restored the Outlook Add-In registration process for Microsoft Teams Meeting Add-in
- Keeps the existing Microsoft Teams installation flow intact